### PR TITLE
docs(formal-verification): add Lean Squad research artifacts

### DIFF
--- a/formal-verification/RESEARCH.md
+++ b/formal-verification/RESEARCH.md
@@ -1,0 +1,178 @@
+# SageFs — Formal Verification Research
+
+> 🔬 *Lean Squad — automated formal verification for `WillEhrendreich/SageFs`.*
+
+## Last Updated
+- **Date**: 2026-04-23 19:55 UTC
+- **Commit**: `c4784d68d4f0c69c21dd4e7255f042868fa3fc80`
+
+---
+
+## Overview
+
+SageFs is a live F# development environment — a REPL-powered daemon with editor integrations. The primary language is **F#**, targeting `.NET 10`. This document surveys the codebase for formal verification candidates and establishes the overall approach.
+
+## FV Tool Choice: Lean 4 + Mathlib
+
+**Rationale**: SageFs is written in F#, not Rust, so Aeneas/Charon (the Rust→Lean extraction pipeline) is not applicable. We use **Lean 4** with **Mathlib** for hand-written formal specifications and proofs. The primary source of truth is the F# source code; Lean models are written by hand, capturing the pure functional core of each target.
+
+**Approach**:
+- Write Lean 4 functional models that mirror the pure F# logic
+- State key correctness properties as Lean `theorem` declarations
+- Prove them with Lean tactics (`omega`, `simp`, `decide`, `cases`, `induction`)
+- Use `sorry` for currently unprovable goals; mark and track them
+- Prefer decidable propositions where possible
+
+**Mathlib relevance**: `Mathlib.Data.List.Basic`, `Mathlib.Data.Nat.Basic`, `Mathlib.Logic.Basic` cover most of what we need for list/count/arithmetic properties.
+
+---
+
+## FV Target Survey
+
+### Target 1: `RingBuffer` — `SageFs.Core/RingBuffer.fs`
+
+**Description**: A fixed-capacity ring buffer for time-travel model snapshots. Pure functional module (each operation returns a new `RingBuffer<'T>` record). Uses a mutable backing array under the hood, but all operations are written in a functional style.
+
+**Why FV-amenable**:
+- All public operations are pure functions with no I/O or external state
+- Clear, testable invariants: `0 ≤ count ≤ capacity`, `evictedCount = totalPushed - count`
+- Rich existing property-test suite (`RingBufferTests.fs`) providing specification hints
+- Simple index arithmetic: `(Head + age) % capacity` — ideal for `omega` / `decide`
+- Already has textbook-style documentation on semantics
+
+**Properties to verify**:
+1. `count buf ≤ capacity buf` — count never exceeds capacity
+2. `evictedCount buf = totalPushed buf - count buf` — accounting identity
+3. `totalPushed` monotonically increases with each `push`
+4. After `n` pushes on a fresh buffer of capacity `c`, `count = min n c`
+5. `(toList buf).Length = count buf` — list length matches count
+6. Most-recent-first ordering: `(push x buf |> tryGet 0) = Some x`
+7. After `clear`, `count = 0` and `capacity` is preserved
+
+**Spec size**: ~80 Lean lines (types + theorems)
+**Proof tractability**: Mostly `omega` / `simp` / `decide` for bounded cases. Induction on push count for the general case. Index-wrap arithmetic requires `omega` or `Nat.mod_cast`.
+**Approximations**: The Lean model uses `List` rather than a mutable array; this models the pure input/output semantics but not the physical memory layout.
+**Phase**: 1 (Research identified) → targeting Phase 2 (Informal Spec)
+
+---
+
+### Target 2: `ResultEx` — `SageFs.Core/ResultEx.fs`
+
+**Description**: Railway-oriented programming combinators for `Result<'T, 'E>`. Provides `map`, `bind`, `mapError`, `apply`, `zip`, `sequence`, `traverse`, `partition`, and utility predicates.
+
+**Why FV-amenable**:
+- All functions are pure, polymorphic, and algebraically structured
+- Functor/monad/applicative laws are classical Lean proof exercises
+- `sequence` and `traverse` have well-known correctness properties
+- No I/O, no mutation, no external state
+
+**Properties to verify**:
+1. Functor identity: `map id r = r`
+2. Functor composition: `map (f ∘ g) r = (map f ∘ map g) r`
+3. Monad left identity: `bind (Ok x) f = f x`
+4. Monad right identity: `bind r Ok = r`
+5. Monad associativity: `bind (bind r f) g = bind r (fun x → bind (f x) g)`
+6. `sequence` correctness: `sequence [Ok a; Ok b] = Ok [a; b]`, first error wins
+7. `zip (Ok a) (Ok b) = Ok (a, b)`, `zip (Error e) _ = Error e`
+8. `isOk ∘ Ok = true`, `isError ∘ Error = true`
+
+**Spec size**: ~100 Lean lines
+**Proof tractability**: Nearly all can be proved by `cases` or `simp` — monad/functor laws on a two-constructor type are essentially trivial in Lean 4. `sequence` requires induction on the list.
+**Approximations**: The Lean proofs work over the abstract `Result` type; the specific `SageFsError` type is not needed for algebraic laws.
+**Phase**: 1 (Research identified)
+
+---
+
+### Target 3: `RetryPolicy` — `SageFs.Core/RetryPolicy.fs`
+
+**Description**: Pure decision function for retry/backoff logic. Given a retryability predicate, a config, an attempt number, and an exception, returns either `RetryAfter delay` or `GiveUp ex`.
+
+**Why FV-amenable**:
+- The `decide` function is entirely pure: no I/O, no mutation
+- Simple finite case analysis: isRetryable × shouldRetry → 4 cases
+- The random jitter in `backoffMs` is NOT pure — we model only the deterministic structure
+- `shouldRetry` is a simple linear predicate: `attempt < config.MaxRetries`
+
+**Properties to verify**:
+1. Non-retryable exceptions always result in `GiveUp`
+2. Retryable exceptions beyond `MaxRetries` result in `GiveUp`
+3. Retryable exceptions within `MaxRetries` result in `RetryAfter`
+4. `shouldRetry config attempt = (attempt < config.MaxRetries)`
+
+**Spec size**: ~60 Lean lines
+**Proof tractability**: All can be proved by `decide` or `cases` — pure case analysis.
+**Approximations**: `backoffMs` with random jitter is not modelled; only the deterministic non-random branch is captured.
+**Phase**: 1 (Research identified)
+
+---
+
+### Target 4: `RestartPolicy` — `SageFs.Core/RestartPolicy.fs`
+
+**Description**: Pure Erlang-style restart policy with exponential backoff and a reset window. `decide` returns `Restart delay` or `GiveUp` depending on restart count vs. policy limits.
+
+**Why FV-amenable**:
+- `decide` and `nextBackoff` are pure functions of their inputs
+- Properties relate to monotonicity, caps, and decision correctness
+- Reset window logic adds mild complexity but is still pure
+
+**Properties to verify**:
+1. `nextBackoff` is monotonically non-decreasing in restart count
+2. `nextBackoff` is always bounded by `policy.BackoffMax`
+3. When `restartCount ≥ policy.MaxRestarts`, `decide` returns `GiveUp`
+4. When count is zero with no window, `decide` returns `Restart`
+
+**Spec size**: ~80 Lean lines
+**Proof tractability**: `linarith` / `norm_num` for the delay bound. Case analysis for decision properties. `DateTime` arithmetic requires some modelling.
+**Approximations**: `DateTime` is modelled as abstract `Int` (ticks or seconds); the reset window check is abstracted.
+**Phase**: 1 (Research identified)
+
+---
+
+### Target 5: `Affordances.availableTools` — `SageFs.Core/Affordances.fs`
+
+**Description**: Pure state machine function mapping `SessionState` (4 states) to the list of MCP tool names valid in that state. Used to enforce the affordance-driven API.
+
+**Why FV-amenable**:
+- Finite domain: exactly 4 session states
+- All properties are decidable: `decide` can close them all
+- Security-relevant: incorrect affordances could expose tools at the wrong time
+- Properties have direct practical meaning
+
+**Properties to verify**:
+1. `send_fsharp_code` is ONLY available in `Ready` state
+2. `cancel_eval` is ONLY available in `Evaluating` and `Ready` states
+3. `create_session` is available in ALL states
+4. No duplicate tool names in any state's list
+5. `checkToolAvailability` returns `Ok ()` iff the tool is in `availableTools`
+6. State transitions preserve the availability monotonicity invariant (adding/removing tools correctly)
+
+**Spec size**: ~80 Lean lines (define state DU + tool lists + theorems)
+**Proof tractability**: All `decide` since the domain is finite and concrete. Very tractable.
+**Approximations**: Tool names are modelled as `String` literals — exact match. State transitions are not modelled (would require SessionManager).
+**Phase**: 1 (Research identified)
+
+---
+
+## Summary Priority Order
+
+| # | Target | File | Benefit | Tractability | Priority |
+|---|--------|------|---------|-------------|----------|
+| 1 | RingBuffer | `SageFs.Core/RingBuffer.fs` | Invariant correctness, rich existing tests | High (omega+simp) | **Highest** |
+| 2 | ResultEx | `SageFs.Core/ResultEx.fs` | Monad/functor laws, algebraic correctness | Very high (cases/simp) | High |
+| 3 | Affordances | `SageFs.Core/Affordances.fs` | Security-relevant, finite decidable domain | Very high (decide) | High |
+| 4 | RetryPolicy | `SageFs.Core/RetryPolicy.fs` | Decision correctness, backoff properties | High (cases/omega) | Medium |
+| 5 | RestartPolicy | `SageFs.Core/RestartPolicy.fs` | Backoff monotonicity, cap invariant | Medium (linarith) | Medium |
+
+---
+
+## Web Research Notes
+
+Lean 4 Mathlib provides:
+- `Mathlib.Data.List.Basic`: `List.length`, `List.take`, `List.get?`, `List.Nodup`
+- `Mathlib.Data.Nat.Basic`: `Nat.min`, `Nat.mod`, modular arithmetic lemmas
+- `Mathlib.Logic.Basic`: propositional logic combinators
+- `decide` tactic: closes decidable propositions automatically — ideal for `Affordances`
+- `omega`: linear integer arithmetic — ideal for `RingBuffer` index/count properties
+- `simp [...]`: conditional rewriting — ideal for monad laws on `Result`
+
+Pattern reference: monad laws for `Result`/`Option` are standard Lean 4 exercises well supported by Mathlib's algebraic hierarchy. We avoid re-proving these if Mathlib already provides them under `Functor`/`Monad` instances.

--- a/formal-verification/TARGETS.md
+++ b/formal-verification/TARGETS.md
@@ -1,0 +1,31 @@
+# SageFs — FV Target List
+
+> 🔬 *Lean Squad — automated formal verification for `WillEhrendreich/SageFs`.*
+
+## Last Updated
+- **Date**: 2026-04-23 19:55 UTC
+- **Commit**: `c4784d68d4f0c69c21dd4e7255f042868fa3fc80`
+
+---
+
+| # | Target | Source File | Phase | Status | Notes |
+|---|--------|-------------|-------|--------|-------|
+| 1 | `RingBuffer` | `SageFs.Core/RingBuffer.fs` | 2 | 🔄 Informal spec written | Pure functional ring buffer; count/capacity/ordering invariants |
+| 2 | `ResultEx` | `SageFs.Core/ResultEx.fs` | 1 | ⬜ Identified | Functor/monad/applicative laws for `Result<'T,'E>` |
+| 3 | `Affordances.availableTools` | `SageFs.Core/Affordances.fs` | 1 | ⬜ Identified | Finite state machine; all properties decidable |
+| 4 | `RetryPolicy.decide` | `SageFs.Core/RetryPolicy.fs` | 1 | ⬜ Identified | Pure retry decision; case analysis |
+| 5 | `RestartPolicy.decide` | `SageFs.Core/RestartPolicy.fs` | 1 | ⬜ Identified | Exponential backoff; monotonicity/cap properties |
+
+## Phase Legend
+
+| Phase | Description |
+|-------|-------------|
+| 1 | Research: target identified, approach noted |
+| 2 | Informal spec extracted (`specs/<name>_informal.md`) |
+| 3 | Lean 4 spec written (`lean/FVSquad/<Name>.lean` with `sorry` proofs) |
+| 4 | Lean 4 implementation model extracted (concrete definitions, not just sigs) |
+| 5 | Proofs attempted; `sorry`s reduced/eliminated |
+
+## Open Issues / PRs
+
+*(None yet — first run)*

--- a/formal-verification/specs/ringbuffer_informal.md
+++ b/formal-verification/specs/ringbuffer_informal.md
@@ -1,0 +1,208 @@
+# Informal Specification: `RingBuffer`
+
+> 🔬 *Lean Squad — automated formal verification for `WillEhrendreich/SageFs`.*
+
+**Source file**: `SageFs.Core/RingBuffer.fs`
+**Module**: `SageFs.RingBuffer`
+**Phase**: 2 — Informal spec
+
+---
+
+## Purpose
+
+`RingBuffer<'T>` is a fixed-capacity circular buffer designed for time-travel model
+snapshots. It holds at most `capacity` items. When full, pushing a new item evicts the
+oldest one. Items are accessed by **age**: age 0 = most recent, age 1 = one step back,
+and so on.
+
+The module provides a purely functional interface: every mutating operation returns a
+new `RingBuffer<'T>` record. The underlying array is mutated in place for performance
+(structural sharing of F# records), but the observable semantics are fully functional.
+
+---
+
+## Type Definition
+
+```fsharp
+type RingBuffer<'T> = {
+  Items: 'T array      // Physical storage, length = capacity
+  Head: int            // Index of the most-recently-pushed slot
+  Count: int           // Number of valid items currently in the buffer
+  TotalPushed: int64   // Total items ever pushed (including evicted)
+}
+```
+
+### Internal representation invariants
+
+These hold for every well-formed `RingBuffer`:
+- `0 < Items.Length` (capacity is always positive — enforced by `create`)
+- `0 ≤ Head < Items.Length`
+- `0 ≤ Count ≤ Items.Length`
+- `TotalPushed ≥ 0`
+- `TotalPushed ≥ Count` (pushed at least as many as are stored)
+- `TotalPushed - Count ≥ 0` — the eviction count is non-negative
+
+---
+
+## Operations
+
+### `create (capacity: int) : RingBuffer<'T>`
+
+**Precondition**: `capacity > 0`
+
+**Postcondition**:
+- Returns a ring buffer with `Count = 0`, `Head = 0`, `TotalPushed = 0`
+- `Items.Length = capacity`
+- Raises `ArgumentException "Ring buffer capacity must be positive"` if
+  `capacity ≤ 0`
+
+---
+
+### `push (item: 'T) (buf: RingBuffer<'T>) : RingBuffer<'T>`
+
+**Precondition**: `buf` is well-formed
+
+**Postcondition** (let `cap = capacity buf`, `n = count buf`):
+- Returns a new buffer with `capacity = cap` (unchanged)
+- `totalPushed result = buf.TotalPushed + 1`
+- `count result = min (n + 1) cap`
+- The pushed item is retrievable as `tryGet 0 result = Some item`
+- If `n > 0` then `tryGet k result = tryGet (k-1) buf` for all `1 ≤ k < count result`
+  (i.e., previously-stored items age by one)
+- The oldest item is evicted if the buffer was full (`n = cap`)
+
+**Index arithmetic**: `newHead = (buf.Head + cap - 1) % cap`
+
+---
+
+### `tryGet (age: int) (buf: RingBuffer<'T>) : 'T option`
+
+**Precondition**: none (safe for any `age`)
+
+**Postcondition**:
+- Returns `None` if `age < 0` or `age ≥ buf.Count`
+- Returns `Some buf.Items[(buf.Head + age) % cap]` otherwise
+
+**Examples**:
+- `tryGet 0 buf` = most recently pushed item, or `None` if empty
+- `tryGet (-1) buf` = `None`
+- `tryGet (count buf) buf` = `None`
+
+---
+
+### `current (buf: RingBuffer<'T>) : 'T option`
+Equivalent to `tryGet 0 buf`.
+
+### `previous (buf: RingBuffer<'T>) : 'T option`
+Equivalent to `tryGet 1 buf`.
+
+---
+
+### `count (buf: RingBuffer<'T>) : int`
+Returns `buf.Count`. Always in `[0, capacity buf]`.
+
+### `capacity (buf: RingBuffer<'T>) : int`
+Returns `buf.Items.Length`. Always positive.
+
+### `isEmpty (buf: RingBuffer<'T>) : bool`
+Returns `buf.Count = 0`. Equivalent to `count buf = 0`.
+
+### `isFull (buf: RingBuffer<'T>) : bool`
+Returns `buf.Count = buf.Items.Length`. Equivalent to `count buf = capacity buf`.
+
+### `totalPushed (buf: RingBuffer<'T>) : int64`
+Total pushes ever. Monotonically non-decreasing.
+
+### `evictedCount (buf: RingBuffer<'T>) : int64`
+Returns `buf.TotalPushed - buf.Count`. Always non-negative.
+
+---
+
+### `toSeq / toList (buf: RingBuffer<'T>) : 'T seq / 'T list`
+
+**Postcondition**:
+- Yields items in **most-recent-first** order: `[item_0, item_1, ..., item_{count-1}]`
+  where `item_k = (tryGet k buf).Value`
+- `(toList buf).Length = count buf`
+- For `0 ≤ k < count buf`: `(toList buf).[k] = (tryGet k buf).Value`
+
+---
+
+### `clear (buf: RingBuffer<'T>) : RingBuffer<'T>`
+
+**Postcondition**:
+- `count result = 0`
+- `capacity result = capacity buf` (preserved)
+- `totalPushed result = buf.TotalPushed` (preserved — history of how many were ever pushed)
+- `isEmpty result = true`
+
+---
+
+## Invariants (Summary)
+
+These hold at all times for a ring buffer produced by the public API:
+
+| # | Invariant | Expression |
+|---|-----------|-----------|
+| I1 | Non-negative count | `0 ≤ count buf` |
+| I2 | Count bounded by capacity | `count buf ≤ capacity buf` |
+| I3 | TotalPushed ≥ count | `totalPushed buf ≥ int64 (count buf)` |
+| I4 | Eviction accounting | `evictedCount buf = totalPushed buf - int64 (count buf)` |
+| I5 | List length matches count | `(toList buf).Length = count buf` |
+| I6 | Most recent accessible | `push x buf \|> tryGet 0 = Some x` |
+| I7 | TotalPushed monotone | After push: `totalPushed new = totalPushed old + 1` |
+| I8 | Capacity preserved by push/clear | `capacity (push x buf) = capacity buf` |
+
+---
+
+## Edge Cases
+
+- **Capacity 1**: The buffer holds exactly one item at a time. Every push evicts the previous item.
+- **Empty buffer**: `tryGet 0`, `current`, `previous` all return `None`.
+- **Exact capacity fill**: After exactly `capacity` pushes, `count = capacity`, `isFull = true`, `evictedCount = 0`.
+- **Wrap-around**: After more than `capacity` pushes, the `Head` index wraps around. The index arithmetic `(Head + age) % capacity` must correctly identify the right slot.
+- **`totalPushed` overflow**: For very long-running sessions, `TotalPushed` is `int64` so overflow only occurs after 2^63 pushes — negligible in practice.
+
+---
+
+## Concrete Examples
+
+```fsharp
+// Create a buffer of capacity 3, push 5 items
+let buf = create 3 |> pushMany [1; 2; 3; 4; 5]
+toList buf     = [5; 4; 3]     // Most recent 3
+count buf      = 3
+totalPushed buf = 5L
+evictedCount buf = 2L
+
+// Capacity 1
+let b1 = create 1 |> push 10 |> push 20
+current b1     = Some 20
+previous b1    = None
+count b1       = 1
+
+// Empty
+let empty = create 5
+current empty  = None
+count empty    = 0
+```
+
+---
+
+## Inferred Intent
+
+The ring buffer is designed for **time-travel debugging**: editors hold a window of recent model snapshots and can step backwards through them. The design choices follow:
+
+- **Most-recent-first** ordering: editors step backwards, so index 0 = current, 1 = one undo
+- **Fixed capacity**: prevents unbounded memory growth; `capacity` is typically small (e.g., 50 snapshots)
+- **`TotalPushed` preserved on `clear`**: even after clearing the snapshot history, the total push count is preserved for audit/diagnostic purposes
+
+---
+
+## Open Questions
+
+1. **Mutation vs. functional semantics**: `push` mutates `Items` in place before returning a new record. If the old `RingBuffer` value is retained, its `Items` array is shared with the new record and may now contain stale data. Is this intentional? Or should `push` copy the array for true immutability? This affects the safety of time-travel if old snapshots are kept.
+
+2. **Thread safety**: The module has no synchronisation. Is `RingBuffer<'T>` intended to be used from a single thread only?
+
+3. **`clear` semantics for `TotalPushed`**: Is it correct that `totalPushed` is preserved across `clear`? The `evictedCount` after `clear` will equal the pre-clear `totalPushed`, which may be surprising if callers interpret `evictedCount` as "how many have been evicted since last clear".


### PR DESCRIPTION
Adds the formal-verification research docs generated by Lean Squad for the first SageFs run.

Closes #53.